### PR TITLE
feat: Changed large elements height to 48px

### DIFF
--- a/.changeset/loud-ties-drive.md
+++ b/.changeset/loud-ties-drive.md
@@ -1,0 +1,5 @@
+---
+'@papyrus-ui/components': patch
+---
+
+Small modals are centered vertically to save space for toast notifications

--- a/.changeset/many-mails-repair.md
+++ b/.changeset/many-mails-repair.md
@@ -1,0 +1,5 @@
+---
+'@papyrus-ui/components': patch
+---
+
+Changed collapsed menu bar height to 56px

--- a/.changeset/nervous-coats-tie.md
+++ b/.changeset/nervous-coats-tie.md
@@ -1,0 +1,5 @@
+---
+'@papyrus-ui/components': patch
+---
+
+Changed large elements height to 48px

--- a/.changeset/smart-pens-look.md
+++ b/.changeset/smart-pens-look.md
@@ -1,0 +1,5 @@
+---
+'@papyrus-ui/components': patch
+---
+
+Toast notifications are centered until the desktop breakpoint

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -231,8 +231,8 @@ const offsetXBySizeMap: Record<InputBoxSize, number> = {
 };
 
 const offsetYBySizeMap: Record<InputBoxSize, number> = {
-  sm: 2 + INITIAL_OFFSET_Y,
-  md: 6 + INITIAL_OFFSET_Y,
+  sm: INITIAL_OFFSET_Y,
+  md: 4 + INITIAL_OFFSET_Y,
   lg: 10 + INITIAL_OFFSET_Y,
 };
 

--- a/packages/components/src/components/button/button.css.ts
+++ b/packages/components/src/components/button/button.css.ts
@@ -150,7 +150,7 @@ export const rootSize = {
   sm: atoms({
     minWidth: 24,
     height: 7,
-    px: 2.5,
+    px: 2,
   }),
   md: atoms({
     minWidth: 28,
@@ -158,8 +158,8 @@ export const rootSize = {
     px: 3,
   }),
   lg: atoms({
-    minWidth: 32,
-    height: 11,
+    minWidth: 36,
+    height: 12,
     px: 4,
   }),
 };

--- a/packages/components/src/components/dialog/dialog-content/dialog-content.css.ts
+++ b/packages/components/src/components/dialog/dialog-content/dialog-content.css.ts
@@ -9,23 +9,22 @@ export const root = atoms({
   width: 'full',
   height: 'full',
   bg: 'dark500',
-  p: {
-    mobile: 0,
-    tablet: 4,
-  },
+
   zIndex: 30,
 });
 
 export const rootSize = {
   sm: atoms({
-    justifyContent: {
-      mobile: 'flex-end',
-      mobileLg: 'center',
-    },
+    justifyContent: 'center',
+    p: 4,
     overflowY: 'auto',
   }),
   md: atoms({
     justifyContent: 'center',
+    p: {
+      mobile: 0,
+      tablet: 4,
+    },
     overflowY: {
       mobile: 'hidden',
       tablet: 'auto',
@@ -33,6 +32,10 @@ export const rootSize = {
   }),
   lg: atoms({
     justifyContent: 'flex-start',
+    p: {
+      mobile: 0,
+      tablet: 4,
+    },
     overflowY: {
       mobile: 'hidden',
       tablet: 'auto',
@@ -50,13 +53,8 @@ export const content = atoms({
 
 export const contentSize = {
   sm: atoms({
-    maxWidth: {
-      mobileLg: 'sm',
-    },
-    roundedTop: 'xl',
-    roundedBottom: {
-      mobileLg: 'xl',
-    },
+    maxWidth: 'sm',
+    rounded: 'xl',
     boxShadow: 'md',
     overflow: 'hidden',
   }),

--- a/packages/components/src/components/icon-button/icon-button.css.ts
+++ b/packages/components/src/components/icon-button/icon-button.css.ts
@@ -160,8 +160,8 @@ export const rootSize = {
     height: 9,
   }),
   lg: atoms({
-    width: 11,
-    height: 11,
+    width: 12,
+    height: 12,
   }),
 };
 

--- a/packages/components/src/components/input-box/input-box.css.ts
+++ b/packages/components/src/components/input-box/input-box.css.ts
@@ -32,7 +32,7 @@ export const rootSize = {
   lg: atoms({
     minHeight: 11,
     px: 2.5,
-    py: 2.5,
+    py: 3,
   }),
 };
 

--- a/packages/components/src/components/menu-bar/menu-bar-submenu/menu-bar-submenu.css.ts
+++ b/packages/components/src/components/menu-bar/menu-bar-submenu/menu-bar-submenu.css.ts
@@ -6,23 +6,10 @@ export const menuList = atoms({
   maxHeight: 80,
   maxWidth: 'xs',
   border: 1,
+  borderColor: 'neutral100',
   rounded: 'lg',
+  bg: 'white',
   boxShadow: 'lg',
   py: 0.5,
   zIndex: 10,
 });
-
-export const menuListVariant = {
-  primary: atoms({
-    borderColor: 'neutral100',
-    bg: 'white',
-  }),
-  secondary: atoms({
-    borderColor: 'neutral100',
-    bg: 'white',
-  }),
-  ghost: atoms({
-    borderColor: 'primary800',
-    bg: 'primary700',
-  }),
-};

--- a/packages/components/src/components/menu-bar/menu-bar-submenu/menu-bar-submenu.tsx
+++ b/packages/components/src/components/menu-bar/menu-bar-submenu/menu-bar-submenu.tsx
@@ -229,7 +229,7 @@ export const MenuBarSubmenu: FC<SubMenuProps> = ({
       refs,
       setActiveIndex,
       size: parent.size,
-      variant: parent.variant === 'primary' ? 'secondary' : parent.variant,
+      variant: 'secondary',
       getItemProps: (userProps = {}) => ({
         ...getItemProps({
           ...userProps,
@@ -249,7 +249,6 @@ export const MenuBarSubmenu: FC<SubMenuProps> = ({
       handleMenuItemKeyDown,
       isOpen,
       parent.size,
-      parent.variant,
       refs,
     ],
   );
@@ -380,7 +379,6 @@ export const MenuBarSubmenu: FC<SubMenuProps> = ({
                     ref={refs.setFloating}
                     className={cn(
                       S.menuList,
-                      S.menuListVariant[parent.variant],
                       fadeStyle,
                       status === 'entered' && fadeInStyle,
                     )}

--- a/packages/components/src/components/menu-button/menu-button.css.ts
+++ b/packages/components/src/components/menu-button/menu-button.css.ts
@@ -26,16 +26,16 @@ export const link = style({
 
 export const linkSize = {
   sm: atoms({
-    px: 1.5,
+    px: 1,
     py: 0.5,
   }),
   md: atoms({
-    px: 2.5,
+    px: 1.5,
     py: 1.5,
   }),
   lg: atoms({
-    px: 3.5,
-    py: 2.5,
+    px: 2.5,
+    py: 3,
   }),
 };
 
@@ -125,7 +125,8 @@ export const linkDisabled = style({
 export const linkCollapsed = style({
   flexDirection: 'column',
   minWidth: 0,
-  padding: `${SPACING[1]} ${SPACING[2]}`,
+  height: '3rem',
+  padding: `0 ${SPACING[2]}`,
 });
 
 export const indent = atoms({
@@ -151,7 +152,7 @@ export const iconVariant = {
 
 export const iconCollapsed = atoms({
   fontSize: '2xl',
-  mb: 1,
+  mb: 0.5,
 });
 
 export const iconCollapsedVariant = {

--- a/packages/components/src/components/menu-button/menu-button.tsx
+++ b/packages/components/src/components/menu-button/menu-button.tsx
@@ -100,7 +100,6 @@ export const MenuButton = forwardRef<HTMLAnchorElement, MenuButtonProps>(
 
         <span
           className={cn(
-            S.label,
             S.labelDirection[direction],
             collapsed
               ? [

--- a/packages/components/src/components/toast-container/toast-container.css.ts
+++ b/packages/components/src/components/toast-container/toast-container.css.ts
@@ -19,7 +19,7 @@ export const rootPlacement = styleVariants({
       justifyContent: 'center',
       transform: 'translateX(-50%)',
     },
-    bpUp('mobileLg', {
+    bpUp('desktop', {
       left: 'auto',
       insetInlineStart: 0,
       justifyContent: 'flex-start',
@@ -33,7 +33,7 @@ export const rootPlacement = styleVariants({
       justifyContent: 'center',
       transform: 'translateX(-50%)',
     },
-    bpUp('mobileLg', {
+    bpUp('desktop', {
       left: 'auto',
       insetInlineEnd: 0,
       justifyContent: 'flex-end',
@@ -53,7 +53,7 @@ export const rootPlacement = styleVariants({
       justifyContent: 'center',
       transform: 'translateX(-50%)',
     },
-    bpUp('mobileLg', {
+    bpUp('desktop', {
       left: 'auto',
       insetInlineStart: 0,
       justifyContent: 'flex-start',
@@ -67,7 +67,7 @@ export const rootPlacement = styleVariants({
       justifyContent: 'center',
       transform: 'translateX(-50%)',
     },
-    bpUp('mobileLg', {
+    bpUp('desktop', {
       left: 'auto',
       insetInlineEnd: 0,
       justifyContent: 'flex-end',

--- a/packages/components/src/components/toast/toast.tsx
+++ b/packages/components/src/components/toast/toast.tsx
@@ -13,6 +13,7 @@ import {
   useCallback,
   useEffect,
 } from 'react';
+import { Transition } from 'react-transition-group';
 
 import { useTimeout } from '../../utils/use-timeout';
 import { Box } from '../box';
@@ -88,6 +89,12 @@ export interface ToastProps extends HTMLAttributes<HTMLDivElement> {
   onAfterHide?: () => void;
 }
 
+const TRANSITION_TIMEOUT = {
+  appear: 0,
+  enter: 200,
+  exit: 200,
+};
+
 const iconByVariant: Record<ToastVariant, string> = {
   primary: 'info-circle',
   danger: 'error-circle',
@@ -155,94 +162,103 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
     }, [onAfterHide, setTimeout, visible]);
 
     return (
-      <div
-        ref={ref}
-        className={cn(
-          S.root,
-          S.rootVariant[variant],
-          fadeStyle,
-          visible && fadeInStyle,
-          className,
-        )}
-        role={role}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        {...props}
+      <Transition
+        in={visible}
+        mountOnEnter
+        timeout={TRANSITION_TIMEOUT}
+        unmountOnExit
       >
-        <Flex alignItems="center" mx="-1.5">
-          <Box lineHeight="none" px={1.5}>
-            {isValidElement<IconProps>(icon) ? (
-              cloneElement(icon, {
-                color: 'white',
-                fontSize: '4xl',
-              })
-            ) : (
-              <Icon
-                color="white"
-                fontSize="4xl"
-                name={iconByVariant[variant]}
-              />
+        {(status) => (
+          <div
+            ref={ref}
+            className={cn(
+              S.root,
+              S.rootVariant[variant],
+              fadeStyle,
+              status === 'entered' && fadeInStyle,
+              className,
             )}
-          </Box>
+            role={role}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            {...props}
+          >
+            <Flex alignItems="center" mx="-1.5">
+              <Box lineHeight="none" px={1.5}>
+                {isValidElement<IconProps>(icon) ? (
+                  cloneElement(icon, {
+                    color: 'white',
+                    fontSize: '4xl',
+                  })
+                ) : (
+                  <Icon
+                    color="white"
+                    fontSize="4xl"
+                    name={iconByVariant[variant]}
+                  />
+                )}
+              </Box>
 
-          <Box flex={1} lineHeight="none" overflow="hidden" px={1.5}>
-            <Text
-              as="div"
-              color="white"
-              fontSize="md"
-              fontWeight="semiBold"
-              letterSpacing="wider"
-              lineHeight="snug"
-              truncate
-            >
-              {message}
-            </Text>
+              <Box flex={1} lineHeight="none" overflow="hidden" px={1.5}>
+                <Text
+                  as="div"
+                  color="white"
+                  fontSize="md"
+                  fontWeight="semiBold"
+                  letterSpacing="wider"
+                  lineHeight="snug"
+                  truncate
+                >
+                  {message}
+                </Text>
 
-            {children && (
-              <Text
-                as="div"
-                color="white"
-                fontSize="sm"
-                fontWeight="regular"
-                letterSpacing="wider"
-                lineHeight="normal"
-                mt={1}
-                truncate
-              >
-                {children}
-              </Text>
-            )}
-          </Box>
+                {children && (
+                  <Text
+                    as="div"
+                    color="white"
+                    fontSize="sm"
+                    fontWeight="regular"
+                    letterSpacing="wider"
+                    lineHeight="normal"
+                    mt={1}
+                    truncate
+                  >
+                    {children}
+                  </Text>
+                )}
+              </Box>
 
-          {actionLabel && onActionClick && (
-            <Box lineHeight="none" px={1.5}>
-              <Button
-                data-testid="action"
-                rounded
-                size="sm"
-                variant="ghost"
-                onClick={onActionClick}
-              >
-                {actionLabel}
-              </Button>
-            </Box>
-          )}
+              {actionLabel && onActionClick && (
+                <Box lineHeight="none" px={1.5}>
+                  <Button
+                    data-testid="action"
+                    rounded
+                    size="sm"
+                    variant="ghost"
+                    onClick={onActionClick}
+                  >
+                    {actionLabel}
+                  </Button>
+                </Box>
+              )}
 
-          {onDismiss && (
-            <Box lineHeight="none" px={1.5}>
-              <IconButton
-                aria-label={dismissLabel}
-                rounded
-                size="sm"
-                variant="ghost"
-                onClick={onDismiss}
-              >
-                <Icon name="x" />
-              </IconButton>
-            </Box>
-          )}
-        </Flex>
-      </div>
+              {onDismiss && (
+                <Box lineHeight="none" px={1.5}>
+                  <IconButton
+                    aria-label={dismissLabel}
+                    rounded
+                    size="sm"
+                    variant="ghost"
+                    onClick={onDismiss}
+                  >
+                    <Icon name="x" />
+                  </IconButton>
+                </Box>
+              )}
+            </Flex>
+          </div>
+        )}
+      </Transition>
     );
   },
 );


### PR DESCRIPTION
## Description

- Small modals are centered vertically to save space for toast notifications
- Changed collapsed menu bar height to 56px
- Changed large elements height to 48px
- Toast notifications are centered until the desktop breakpoint

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
