### PR TITLE
fix(release): stop forwarding --yes onto git commit

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           git config --global user.email "${GIT_AUTHOR_EMAIL}"
           git config --global user.name "${GIT_AUTHOR_NAME}"
-          pnpm ci:versionup:${SEMVER} --yes
+          pnpm ci:versionup:${SEMVER}
         env:
           SEMVER: ${{ github.event.inputs.semver }}
           GIT_AUTHOR_NAME: ${{ github.actor }}


### PR DESCRIPTION
## Overview

**release:** Stop forwarding --yes onto git commit. ([69c1115](https://github.com/mrwskx/papyrus-ui/commit/69c1115fa2682904d0b872e17f6e9fc272d6c1b1))

Drop the redundant --yes from the workflow invocation. pnpm appends
trailing args to the end of the composed script string, and
ci:versionup:* is an && chain, so the flag landed on git commit rather
than on lerna version, failing with exit code 129.

The lerna version call already carries its own --yes inside the script,
so the workflow copy was misplaced as well as redundant.

## Checklist

- [x] If PR closes an issue, that issue's checklist is reviewed and completed
