### PR TITLE
ci: add claude-implement and claude-mention workflows

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,12 +1,25 @@
 ---
 name: implement
-description: Read a GitHub issue and implement the fix or feature. Never closes, comments on, or edits the issue. User-invoked only.
+description: Read a GitHub issue and implement the fix or feature. Never closes, comments on, or edits the issue. Invoked explicitly only — by the user locally, or by the claude-implement workflow under GitHub Actions.
 disable-model-invocation: true
 ---
 
 # Implement
 
 Read a GitHub issue and implement the fix or feature.
+
+## Surface
+
+Steps 4–6 differ depending on where the skill runs. Check once, up front:
+
+```bash
+[ -n "$GITHUB_ACTIONS" ] && echo unattended || echo local
+```
+
+- **local** — a supervised session. You summarize and stop; the user commits.
+- **unattended** — a GitHub Actions run. There is no user and the runner is destroyed when the job ends, so uncommitted work is lost. Commit as you go and finish with a draft PR.
+
+Everything before Step 4 is identical on both surfaces.
 
 ## Step 1 — Resolve issue number
 
@@ -53,13 +66,19 @@ Write in vertical slices — one behavior at a time. No speculative code, no abs
 
 Run typechecking and single test files regularly throughout. Run the full test suite once at the end.
 
+**Unattended only:** invoke `/commit-changes` after each vertical slice, as soon as its tests pass. An unattended run can be cut short by a turn cap or a job timeout at any point — committing per slice means what it finished so far survives as a reviewable branch instead of being discarded with the runner.
+
 **Completion criterion:** the issue's acceptance criteria are met, all existing tests pass, and no code exists that the issue didn't require.
 
 ## Step 5 — Review
 
-Invoke `/code-review` on the completed work before summarizing.
+**Local only.** Invoke `/code-review` on the completed work before summarizing.
 
-## Step 6 — Summary
+Skip this step when unattended. `/code-review` fans out three parallel sub-agents, and an unattended run's output is a draft PR that gets reviewed anyway — locally, or by commenting `@claude` on the PR.
+
+## Step 6 — Finish
+
+### Local
 
 Output a concise summary:
 
@@ -70,3 +89,9 @@ Output a concise summary:
 - What was deliberately skipped (ponytail tradeoffs, if any)
 
 **Do not commit.** Stop here — committing is the user's next step.
+
+### Unattended
+
+Commit anything still uncommitted with `/commit-changes`, then invoke `/open-pr --draft`.
+
+Report the same summary as the local path, plus the PR URL. Do not comment on, edit, or close the issue — the constraint from Step 2 holds on both surfaces. The draft PR is the whole output; linking it back to the issue is the reviewer's call.

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -6,7 +6,8 @@ description: >
   job finds it already correct and exits immediately), and creates the PR
   from the repo's PULL_REQUEST_TEMPLATE.md. Use when the user says "open a
   PR", "open a pull request", "create a PR", "push and open PR", or invokes
-  `/open-pr`.
+  `/open-pr`. Pass `--draft`, or run under GitHub Actions, to open it as a
+  draft.
 ---
 
 ## Steps
@@ -61,8 +62,13 @@ Read `.github/PULL_REQUEST_TEMPLATE.md`. Replace the HTML-comment line under `##
 
 ### 5. Create the PR
 
+Open as a draft when either holds:
+
+- the invocation asked for one (`/open-pr --draft`)
+- `$GITHUB_ACTIONS` is set — an unattended run never opens a PR that is ready for review
+
 ```bash
-gh pr create --title "<title>" --base main --body "$(cat <<'EOF'
+gh pr create [--draft] --title "<title>" --base main --body "$(cat <<'EOF'
 <body>
 EOF
 )"

--- a/.agents/skills/ponytail-review/SKILL.md
+++ b/.agents/skills/ponytail-review/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ponytail-review
+description: >
+  Code review focused exclusively on over-engineering. Finds what to delete:
+  reinvented standard library, unneeded dependencies, speculative abstractions,
+  dead flexibility. One line per finding: location, what to cut, what replaces
+  it. Use when the user says "review for over-engineering", "what can we
+  delete", "is this over-engineered", "simplify review", or invokes
+  /ponytail-review. Complements correctness-focused review, this one only
+  hunts complexity.
+---
+
+Review diffs for unnecessary complexity. One line per finding: location, what
+to cut, what replaces it. The diff's best outcome is getting shorter.
+
+## Format
+
+`L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
+multi-file diffs.
+
+Tags:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+## Scoring
+
+End with the only metric that matters: `net: -<N> lines possible.`
+
+If there is nothing to cut, say `Lean already. Ship.` and stop.
+
+## Boundaries
+
+Complexity only, correctness bugs, security holes, and performance go to a
+normal review pass, not this one. A single smoke test or `assert`-based
+self-check is the ponytail minimum, not bloat, never flag it for deletion.
+Does not apply the fixes, only lists them.
+"stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/.agents/skills/ponytail/SKILL.md
+++ b/.agents/skills/ponytail/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
+  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
+  "minimal solution", "yagni", "do less", or "shortest path", and whenever
+  they complain about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies.
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Stdlib does it?** Use it.
+3. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+4. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+5. **Can it be one line?** One line.
+6. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project. Two rungs work → take the
+higher one and move on. The first lazy solution that works is the right one.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,103 @@
+name: Claude Implement
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  guard:
+    # Issues only, and only for a deliberate `/implement` command.
+    if: >-
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/implement')
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check.outputs.ok }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - name: Check preconditions
+        id: check
+        env:
+          HAS_LABEL: ${{ contains(github.event.issue.labels.*.name, 'ready-for-agent') }}
+          TRUSTED_AUTHOR: ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) }}
+        run: |
+          if [[ "$TRUSTED_AUTHOR" != "true" ]]; then
+            # The action gates who *triggers* a run, not who wrote the body it reads.
+            # An outside-authored issue is untrusted input to an agent with write access.
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "reason=this issue was opened by an outside author. Rewrite it as a maintainer-authored spec with \`/to-spec\` before implementing." >> "$GITHUB_OUTPUT"
+          elif [[ "$HAS_LABEL" != "true" ]]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "reason=this issue is not labelled \`ready-for-agent\`. Run \`/triage\` first, or apply the label if it is already specified." >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  implement:
+    needs: guard
+    if: needs.guard.outputs.ok == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: claude-implement-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # /open-pr needs history for `git rev-list origin/main..HEAD`.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "claude[bot]"
+          git config user.email "claude[bot]@users.noreply.github.com"
+
+      - name: Implement the issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Do NOT pass github_token: with the default GITHUB_TOKEN, GitHub will
+          # not fire workflows on the agent's commits and ci.yml never runs.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: '/implement ${{ github.event.issue.number }}'
+          # No plugin_marketplaces/plugins: ponytail and ponytail-review are
+          # vendored into .agents/skills, so the checkout resolves them and the
+          # run makes no marketplace fetch.
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 40
+
+  refuse:
+    needs: guard
+    if: needs.guard.outputs.ok != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain why nothing ran
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          REASON: ${{ needs.guard.outputs.reason }}
+        run: |
+          gh issue comment "$ISSUE" --repo "$REPO" \
+            --body "Did not start an implementation run: $REASON"

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,59 @@
+name: Claude Mention
+
+# Iteration surface for pull requests: comment `@claude <instruction>` on a PR
+# or a review thread. Issues are deliberately excluded — `/implement` is the
+# only way to start work from an issue.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      (github.event_name == 'pull_request_review_comment' ||
+       github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "claude[bot]"
+          git config user.email "claude[bot]@users.noreply.github.com"
+
+      - name: Respond to the mention
+        uses: anthropics/claude-code-action@v1
+        with:
+          # No prompt input: interactive mode, so Claude responds to the
+          # @claude trigger phrase and posts progress on the thread.
+          # Do NOT pass github_token — see claude-implement.yml.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --model claude-sonnet-5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,14 +35,16 @@ Match user's request to skill and invoke.
 | `prototype`                 | "prototype this", "spike it", "does this state model feel right", "try a few UI variations" |
 | `diagnosing-bugs`           | "diagnose this", "debug this", something broken / throwing / failing / slow                 |
 | `resolving-merge-conflicts` | "resolve the conflicts", "fix this merge", "finish the rebase"                              |
+| `ponytail`                  | "be lazy", "simplest solution", "yagni", "do less", complaints about over-engineering       |
 
 ### Review & Ship
 
-| Skill            | Trigger                                                                                             |
-| ---------------- | --------------------------------------------------------------------------------------------------- |
-| `code-review`    | "review this branch", "review since main", "review my changes", `/code-review`                      |
-| `commit-changes` | "commit", "commit this", "commit my changes", "make a commit", "create a commit", `/commit-changes` |
-| `open-pr`        | "open a PR", "open a pull request", "create a PR", "push and open PR", `/open-pr`                   |
+| Skill             | Trigger                                                                                             |
+| ----------------- | --------------------------------------------------------------------------------------------------- |
+| `code-review`     | "review this branch", "review since main", "review my changes", `/code-review`                      |
+| `commit-changes`  | "commit", "commit this", "commit my changes", "make a commit", "create a commit", `/commit-changes` |
+| `open-pr`         | "open a PR", "open a pull request", "create a PR", "push and open PR", `/open-pr`                   |
+| `ponytail-review` | "review for over-engineering", "what can we delete", "is this over-engineered", `/ponytail-review`  |
 
 ### Research
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,32 @@
+# Third-party notices
+
+## ponytail
+
+`.agents/skills/ponytail/SKILL.md` and `.agents/skills/ponytail-review/SKILL.md`
+are vendored verbatim from the ponytail plugin, v4.7.0
+(<https://github.com/DietrichGebert/ponytail>).
+
+They are checked in rather than installed as a plugin so that unattended agent
+runs resolve them from the repository, with no marketplace fetch at runtime.
+
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Overview

Already up to date
Done in 423ms using pnpm v11.8.0
Already up to date
Done in 412ms using pnpm v11.8.0
### Features

* **skills:** Run implement and open-pr unattended in CI. ([b5b123e](https://github.com/mrwskx/papyrus-ui/commit/b5b123ef7c63602ae436cf4af082b98173f0b3aa))

* **skills:** Vendor ponytail and ponytail-review. ([69e15ab](https://github.com/mrwskx/papyrus-ui/commit/69e15abb0fa135f1f33bb6413d8760f5cddd8de8))

### CI

* Add claude-implement and claude-mention workflows. ([9d2fb69](https://github.com/mrwskx/papyrus-ui/commit/9d2fb69b6873844f4804fb2ff23c2ccbd482590a))

## Checklist

- [x] If PR closes an issue, that issue's checklist is reviewed and completed