### PR TITLE
ci: format release-please PR files before ci runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,43 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please commits CHANGELOG.md/package.json straight through the
+      # GitHub API, bypassing prettier, so the release PR fails `format:check`
+      # in ci.yml until we format it ourselves and push the fix back.
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup pnpm
+        if: ${{ steps.release.outputs.pr }}
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.pr }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Format release PR files
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          pnpm format
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: format release files"
+            git push origin HEAD:${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          fi
+
       - name: Checkout
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4


### PR DESCRIPTION
Release-please-action commits CHANGELOG.md and package.json bumps
directly through the GitHub API, bypassing prettier, so the standing
release PR fails the format:check job. Run pnpm format on the PR
branch and push the fix back whenever release-please opens or updates
the PR.

Repro: prettier --check flags release-please's default CHANGELOG.md
output (double blank lines after headings, star bullets instead of
dashes), confirming the mismatch with the repo's prettier config.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WoRV7oLueLydjYVGbXb4t