### PR TITLE
ci: amend release-please commit instead of stacking a formatting one

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,9 @@ jobs:
 
       # release-please commits CHANGELOG.md/package.json straight through the
       # GitHub API, bypassing prettier, so the release PR fails `format:check`
-      # in ci.yml until we format it ourselves and push the fix back.
+      # in ci.yml until we format it ourselves. Amended into release-please's
+      # own commit (same author/message) rather than stacked on top, since
+      # this branch carries no human commits to preserve.
       - name: Checkout release PR branch
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
@@ -71,11 +73,10 @@ jobs:
         run: |
           pnpm format
           if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "chore: format release files"
-            git push origin HEAD:${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+            git config user.name "$(git log -1 --format='%an')"
+            git config user.email "$(git log -1 --format='%ae')"
+            git commit -a --amend --no-edit
+            git push --force-with-lease origin HEAD:${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           fi
 
       - name: Checkout


### PR DESCRIPTION
## Overview

Amend release-please commit instead of stacking a formatting one. ([522bbad](https://github.com/mrwskx/papyrus-ui/commit/522bbad94b93fa16eacd5e8c79a8920cce324366))

Release-please's PR branch carries a single bot-authored commit with
no human history to protect, so formatting it in place preserves the
intended one-commit-per-release-PR shape instead of adding a second
"chore: format release files" commit on top. git commit --amend keeps
the original author; user.name/user.email are set from the existing
commit first so the committer field matches too. Amending rewrites the
SHA, so the push back needs --force-with-lease.

## Checklist

- [ ] If PR closes an issue, that issue's checklist is reviewed and completed


---
_Generated by [Claude Code](https://claude.ai/code/session_012WoRV7oLueLydjYVGbXb4t)_