### PR TITLE
fix(release): fetch enough depth to amend without orphaning commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,12 +46,18 @@ jobs:
       # in ci.yml until we format it ourselves. Amended into release-please's
       # own commit (same author/message) rather than stacked on top, since
       # this branch carries no human commits to preserve.
+      #
+      # fetch-depth must be >1: a depth-1 (shallow) checkout hides the
+      # commit's parent, so `git commit --amend` below would rewrite it as a
+      # parentless orphan, and GitHub's diff against main would show the
+      # entire repo as added.
       - name: Checkout release PR branch
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 2
 
       - name: Setup pnpm
         if: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
## Overview

**release:** Fetch enough depth to amend without orphaning commits. ([3b7b70f](https://github.com/mrwskx/papyrus-ui/commit/3b7b70f777915ad6022fff42414ce8277b9b527e))

Actions/checkout defaults to fetch-depth 1, a shallow clone where the
checked-out commit reports zero parents even though it has one. Git
commit --amend against that shallow HEAD reused the missing parent
list, turning release-please's commit into a true orphan with no
shared history with main. GitHub then diffed the release PR against
an empty tree instead of main, showing the entire repo as added, and
release-please treated the branch as invalid and recreated it every
run without a release PR ever sticking around.

Reproduced in isolation: a shallow depth-1 clone shows an empty parent
list before any edit, and amending it keeps it empty; a depth-2 clone
preserves the parent through the amend. Bumping fetch-depth to 2 on
the release PR branch checkout fixes it.

## Checklist

- [ ] If PR closes an issue, that issue's checklist is reviewed and completed


---
_Generated by [Claude Code](https://claude.ai/code/session_012WoRV7oLueLydjYVGbXb4t)_