### PR TITLE
fix(release): grant id-token permission for npm trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: release-please-${{ github.ref }}


### PR DESCRIPTION
## Overview

**release:** Grant id-token permission for npm trusted publishing. ([99e1114](https://github.com/mrwskx/papyrus-ui/commit/99e1114ada422652c3c7326955a0a7f674c60326))

Publish to npm failed with a 404 on PUT to registry.npmjs.org/papyrus-ui
even though the package is published and the name/publishConfig match.
The line above the error explains it: pnpm skipped OIDC trusted
publishing because the workflow had no id-token permission, then fell
back to the classic NODE_AUTH_TOKEN path, which npm rejected (npm
returns 404 rather than 403 when a token lacks publish rights, to
avoid leaking package existence).

Adding id-token: write lets pnpm complete the OIDC handshake it was
already attempting instead of silently falling back.

## Checklist

- [ ] If PR closes an issue, that issue's checklist is reviewed and completed


---
_Generated by [Claude Code](https://claude.ai/code/session_012WoRV7oLueLydjYVGbXb4t)_